### PR TITLE
Fix deploy crash when watch flag is removed

### DIFF
--- a/source/class/qx/tool/compiler/cli/commands/Compile.js
+++ b/source/class/qx/tool/compiler/cli/commands/Compile.js
@@ -533,7 +533,7 @@ Framework: v${qxVersion} in ${await this.getQxPath()}`);
       }
 
       let compilerOptions = {
-        watch: this.argv.watch,
+        watch: this.argv.watch ?? false,
         maxWorkers: this.argv.maxWorkers,
         typescriptEnabled: qx.lang.Type.isBoolean(this.argv.typescript)
       };


### PR DESCRIPTION
## Problem

`qx deploy` crashes with:

```
Error: Invalid value for property qx.tool.compiler.Compiler.watch: undefined
```

`Deploy` removes the `watch` flag (`Deploy.js`: `cmd.removeFlag("watch")`) but inherits `process()` from `Compile`. There, `compilerOptions` is built with `watch: this.argv.watch`. Since the flag was removed, `this.argv.watch` is `undefined`, which is then passed into the non-nullable Boolean property `qx.tool.compiler.Compiler.watch`, triggering the validation error.

## Fix

Default to `false` when the flag is absent:

```js
watch: this.argv.watch ?? false,
```

This covers `deploy` and any other command derived from `Compile` that removes the `watch` flag.