### PR TITLE
Use shell on Windows when spawning bootstrap commands

### DIFF
--- a/bin/tools/utils.js
+++ b/bin/tools/utils.js
@@ -50,9 +50,10 @@ async function runCommand(dir, ...args) {
     if (DEBUG) {
       console.debug(`    [[DEBUG]] Running command in ${dir}: ${originalCmd} ${args.join(" ")}`);
     }
-    let proc = child_process.spawn(originalCmd, args, { 
+    let proc = child_process.spawn(originalCmd, args, {
       cwd: dir,
-      env: env
+      env: env,
+      shell: process.platform === "win32"
     });
     let result = { exitCode: null, output: "", error: "", messages: null };
     proc.stdout.on("data", data => { 


### PR DESCRIPTION
## Problem

The bootstrap fails on Windows because `runCommand` in `bin/tools/utils.js` spawns commands without a shell:

```js
let proc = child_process.spawn(originalCmd, args, {
  cwd: dir,
  env: env
});
```

On Windows, `.cmd`/`.bat` launchers and PATH-based command resolution require a shell, so `spawn` throws `ENOENT` and the bootstrap chain breaks.

## Fix

Enable a shell only on `win32`, leaving argument handling untouched on Linux/macOS:

```js
let proc = child_process.spawn(originalCmd, args, {
  cwd: dir,
  env: env,
  shell: process.platform === "win32"
});
```