### PR TITLE
ci: update actions to v4 and replace deprecated ::set-output

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -9,8 +9,8 @@ jobs:
     name: Check markdown in changed files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - name: Install dependencies
         run: .github/workflows/markdown-lint-install
       - id: file_changes

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,8 +27,8 @@ jobs:
     if: ${{ github.repository == 'qooxdoo/qooxdoo' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 14
       - run: |

--- a/.github/workflows/on-push-tag.yml
+++ b/.github/workflows/on-push-tag.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'qooxdoo/qooxdoo' }}
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
       - uses: octokit/graphql-action@v2.x
         id: get_repo_names
         with:
@@ -31,7 +31,7 @@ jobs:
           d = d.search.edges.map(item=>item.node.name);
           console.log(JSON.stringify(d,null,0));
           HEREDOC
-          echo "::set-output name=repos::$(cat data.json)"
+          echo "repos=$(cat data.json)" >> "$GITHUB_OUTPUT"
     outputs:
       repos: ${{ steps.transform.outputs.repos }}
 

--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: use node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
GitHub Actions warns that `actions/checkout@v2` and `actions/setup-node@v3` (and older) target Node.js 20, which is deprecated on GitHub-hosted runners.

## Changes
- Bump `actions/checkout` and `actions/setup-node` to **v4** across all workflows so they run natively on Node.js 24.
- Replace the deprecated `::set-output` workflow command with the `$GITHUB_OUTPUT` file syntax in `on-push-tag.yml`.

## Affected workflows
- `test-framework.yml` (checkout@v2 → v4, setup-node@v3 → v4)
- `on-push-tag.yml` (setup-node@v2 → v4, ::set-output → $GITHUB_OUTPUT)
- `npm-publish.yml` (checkout@v1 → v4, setup-node@v1 → v4)
- `markdown-lint.yml` (checkout@v2 → v4, setup-node@v2 → v4)