### PR TITLE
fix: make test-issues pass again (compiler warnings, --warn-as-error, fatal-error exit codes)

### DIFF
--- a/source/class/qx/tool/compiler/Compiler.js
+++ b/source/class/qx/tool/compiler/Compiler.js
@@ -375,7 +375,10 @@ qx.Class.define("qx.tool.compiler.Compiler", {
       }
 
       try {
-        let promises = this.__makers.map(maker => maker.make());
+        // Route the initial make through __makeMaker so that __makingMakers is populated;
+        // this de-duplicates the redundant make that _onClassCompiled would otherwise trigger
+        // while this make is still running, which caused a premature "allMakersMade" event.
+        let promises = this.__makers.map(maker => this.__makeMaker(maker));
         await Promise.all(promises);
         console.log("All makers made");
       } catch (ex) {
@@ -606,19 +609,9 @@ qx.Class.define("qx.tool.compiler.Compiler", {
         }
       }
 
-      //Only print the markers when we are making,
-      //because all the classes get re-checked anyway when we make
-      //and this will prevent duplicated markers being printed
-      if (Object.keys(this.__makingMakers).length > 0) {
-        let markers = result.dbClassInfo.markers;
-        if (markers) {
-          markers.forEach(function (marker) {
-            var str = qx.tool.compiler.Console.decodeMarker(marker);
-            qx.tool.compiler.Console.warn(classname + ": " + str + ` (${analyzer.getMaker().getTarget().getOutputDir()})`);
-          });
-        }
-      }
-
+      // Markers (warnings/errors) are printed once per make cycle in Maker.make(),
+      // which is deterministic; printing them here duplicated output because classes
+      // can be transpiled more than once during a single compile.
       let makers = Object.values(this.__dirtyMakers);
       if (makers.length === 0 || Object.keys(this.__compilingClasses).length != 0) {
         return;
@@ -699,6 +692,16 @@ qx.Class.define("qx.tool.compiler.Compiler", {
      */
     getMakers() {
       return this.__makers;
+    },
+
+    /**
+     * Whether an error occurred during `start()` (e.g. discovered classes could not be added
+     * to the meta database)
+     *
+     * @returns {Boolean}
+     */
+    hasStartError() {
+      return Boolean(this.__startError);
     },
 
     /**

--- a/source/class/qx/tool/compiler/Maker.js
+++ b/source/class/qx/tool/compiler/Maker.js
@@ -386,21 +386,6 @@ qx.Class.define("qx.tool.compiler.Maker", {
           success = false;
           continue;
         }
-        if (!hasWarnings) {
-          application.getDependencies().forEach(classname => {
-            let dbClassInfo = analyzer.getDbClassInfo(classname);
-            if (!dbClassInfo?.markers) {
-              return;
-            }
-            for (let marker of dbClassInfo.markers) {
-              let type = qx.tool.compiler.Console.getInstance().getMessageType(marker.msgId);
-              if (type == "warning") {
-                hasWarnings = true;
-                break;
-              }
-            }
-          });
-        }
 
         let appInfo = appsThisTime[i];
 
@@ -411,6 +396,28 @@ qx.Class.define("qx.tool.compiler.Maker", {
       }
 
       await this.fireDataEventAsync("writtenApplications", allAppInfos);
+
+      // Report markers (warnings/errors) for every class compiled in this make cycle,
+      // and flag whether any warnings were produced (used for --warn-as-error). This is
+      // done here - rather than per class as it is compiled - because a class can be
+      // transpiled more than once per compile, which would duplicate the output. Using
+      // the full list of compiled classes (rather than just an application's load
+      // dependencies) ensures markers on classes that are only referenced at runtime
+      // are still reported.
+      let outputDir = this.getTarget().getOutputDir();
+      let Console = qx.tool.compiler.Console.getInstance();
+      for (let classname of analyzer.getCompiledClassnames()) {
+        let dbClassInfo = analyzer.getDbClassInfo(classname);
+        if (!dbClassInfo?.markers) {
+          continue;
+        }
+        for (let marker of dbClassInfo.markers) {
+          if (Console.getMessageType(marker.msgId) == "warning") {
+            hasWarnings = true;
+          }
+          qx.tool.compiler.Console.warn(classname + ": " + qx.tool.compiler.Console.decodeMarker(marker) + ` (${outputDir})`);
+        }
+      }
 
       await analyzer.saveDatabase();
       this.setSuccess(success);

--- a/source/class/qx/tool/compiler/cli/commands/Compile.js
+++ b/source/class/qx/tool/compiler/cli/commands/Compile.js
@@ -1342,7 +1342,7 @@ Framework: v${qxVersion} in ${await this.getQxPath()}`);
       if (this.argv.watch) {
         await new qx.Promise();
       } else {
-        await compiler.stop();
+        return await this._exit();
       }
     },
 
@@ -1517,7 +1517,9 @@ Framework: v${qxVersion} in ${await this.getQxPath()}`);
      * @returns {integer} the process exit code
      */
     async _exit() {
-      let makers = this.getMakers();
+      // getMakers() is declared async in ICompilerInterface, so custom compilers may
+      // implement it asynchronously - await it to support both sync and async variants.
+      let makers = await this.getMakers();
       let success = makers.every(maker => maker.success) && !this.__compiler.hasStartError();
       let hasWarnings = makers.some(maker => maker.hasWarnings);
       if (success && hasWarnings && this.argv.warnAsError) {

--- a/source/class/qx/tool/worker/JobQueue.js
+++ b/source/class/qx/tool/worker/JobQueue.js
@@ -153,7 +153,10 @@ qx.Class.define("qx.tool.worker.JobQueue", {
     __executeJob(job, workerClient) {
       job.status = "running";
       let api = workerClient.getApi(job.jobApiName);
-      api[job.jobMethodName].apply(api, job.jobArgs).then(result => this.__onJobComplete(job, workerClient, result));
+      api[job.jobMethodName]
+        .apply(api, job.jobArgs)
+        .then(result => this.__onJobComplete(job, workerClient, result))
+        .catch(err => this.__onJobError(job, workerClient, err));
     },
 
     /**
@@ -174,6 +177,33 @@ qx.Class.define("qx.tool.worker.JobQueue", {
       job.promiseComplete.resolve(result);
 
       // Shortcut to process the next job in the queue if there is one, otherwise mark the worker as idle
+      if (this.__queue.length) {
+        this.__pollQueue(workerClient);
+        return;
+      }
+      delete this.__busyWorkerClients[workerClient.toUuid()];
+      this.__idleWorkerClients.push(workerClient);
+    },
+
+    /**
+     * Called when a job fails; rejects the job's completion promise so the caller can
+     * handle the failure (e.g. mark the class as having a fatal compile error) instead
+     * of the rejection escaping as an unhandled error.
+     *
+     * @param {Job} job
+     * @param {qx.tool.worker.WorkerClient} workerClient
+     * @param {Error} err
+     */
+    __onJobError(job, workerClient, err) {
+      if (!this.__jobsByUuid[job.jobUuid]) {
+        // If the job is not found, it may have been removed from the queue, so we can ignore it
+        return;
+      }
+
+      job.status = "complete";
+      job.promiseComplete.reject(err);
+
+      // Continue processing the queue / release the worker, exactly as on success
       if (this.__queue.length) {
         this.__pollQueue(workerClient);
         return;


### PR DESCRIPTION
DRAFT: First https://github.com/johnspackman/qooxdoo/pull/6 must be merged so that lint is happy again.


Fixes the 5 failing `test-issues` tests (Issue440 + the four Issue10407 tests) — regressions from the worker/separate-process refactor. Now 13/13 pass (was 8/13).

- **Fatal errors ignored:** `JobQueue.__executeJob` had no `.catch()`, so a rejected worker job (e.g. a Babel parse error) escaped as an unhandled rejection and left `promiseComplete` pending. Added `__onJobError` → parse/compile failures now propagate and the compiler exits non-zero.
- **Warnings not printed:** markers are now reported once per make in `Maker.make()` over all compiled classes (covers runtime-only deps); the duplicate/suppressed per-class print in `Compiler` was removed.
- **`--warn-as-error` ignored:** `Compile._exit()` was dead code — the non-watch path now returns it (and awaits async `getMakers()`); restored `Compiler.hasStartError()`.
- **Watch misses new files:** the initial make is routed through `__makeMaker` so `__makingMakers` is populated, removing a redundant make that fired a premature `allMakersMade`.