### PR TITLE
fix: make qx typescript work again and honour --exclude

### DIFF
--- a/source/class/qx/tool/compiler/cli/commands/Typescript.js
+++ b/source/class/qx/tool/compiler/cli/commands/Typescript.js
@@ -146,28 +146,37 @@ qx.Class.define("qx.tool.compiler.cli.commands.Typescript", {
         }
       }
 
-      let metaDb = new qx.tool.compiler.meta.MetaDatabase();
-      await metaDb.load();
+      // MetaDatabase parses classes via the job queue, so it needs a started
+      // JobQueue.  The default (maxConcurrentJobs = 1) uses an in-process loopback
+      // worker, which is all this command needs.
+      let jobQueue = new qx.tool.worker.JobQueue();
+      await jobQueue.start();
+      try {
+        let metaDb = new qx.tool.compiler.meta.MetaDatabase(jobQueue);
+        await metaDb.load();
 
-      // Register scanned dirs as libraries if not already present (needed when no db.json exists yet)
-      const db = metaDb.getDatabase();
-      if (!db.libraries) {
-        db.libraries = {};
-      }  
-      for (let dir of files) {
-        const resolved = path.resolve(dir);
-        if (!Object.values(db.libraries).some(l => path.resolve(l.sourceDir) === resolved)) {
-          db.libraries[resolved] = { sourceDir: resolved };
+        // Register scanned dirs as libraries if not already present (needed when no db.json exists yet)
+        const db = metaDb.getDatabase();
+        if (!db.libraries) {
+          db.libraries = {};
         }
-      }
+        for (let dir of files) {
+          const resolved = path.resolve(dir);
+          if (!Object.values(db.libraries).some(l => path.resolve(l.sourceDir) === resolved)) {
+            db.libraries[resolved] = { sourceDir: resolved };
+          }
+        }
 
-      await metaDb.loadFromDirectories(files, { ignore: ig, verbose: this.argv.verbose });
+        await metaDb.loadFromDirectories(files, { ignore: ig, verbose: this.argv.verbose });
 
-      let tsWriter = new qx.tool.compiler.targets.TypeScriptWriter(metaDb);
-      if (this.argv.outputFilename) {
-        tsWriter.setOutputTo(this.argv.outputFilename);
+        let tsWriter = new qx.tool.compiler.targets.TypeScriptWriter(metaDb);
+        if (this.argv.outputFilename) {
+          tsWriter.setOutputTo(this.argv.outputFilename);
+        }
+        await tsWriter.process();
+      } finally {
+        await jobQueue.stop();
       }
-      await tsWriter.process();
     }
   }
 });

--- a/source/class/qx/tool/compiler/meta/MetaDatabase.js
+++ b/source/class/qx/tool/compiler/meta/MetaDatabase.js
@@ -742,6 +742,32 @@ qx.Class.define("qx.tool.compiler.meta.MetaDatabase", {
         await this.addFile(filename, options.force || false);
       }
       await this.reparseAll();
+
+      // Remove any classes whose source file is excluded by the ignore patterns.
+      // Scanning already skips excluded files, but classes parsed by a previous run
+      // may have been reloaded from the persisted database (db.json) by load(), so
+      // filter them out here to keep excluded classes out of the result.
+      if (options.ignore) {
+        for (let classname of this.getClassnames()) {
+          let meta = this.getMetaData(classname);
+          if (!meta || !meta.classFilename) {
+            continue;
+          }
+          let sourcePath = path.resolve(path.join(this.getRootDir(), meta.classFilename));
+          let relativePath = path.relative(process.cwd(), sourcePath);
+          // Files outside the current working directory cannot be matched by the
+          // relative ignore patterns (and the `ignore` package rejects "../" paths),
+          // so they are never excluded.
+          if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+            continue;
+          }
+          if (options.ignore.ignores(relativePath)) {
+            delete this.__classMetasByClassname[classname];
+            delete this.__metaByFilename[sourcePath];
+            delete this.__dirtyClasses[classname];
+          }
+        }
+      }
     }
   }
 });


### PR DESCRIPTION
**DRAFT: First https://github.com/johnspackman/qooxdoo/pull/6 must be merged so that lint is happy again.**

Fixes `test-qx-typescript` (5/5, was 4/5) — regressions from the worker/separate-process refactor:

- **Command crashed:** `MetaDatabase` parses via a `JobQueue` now, but the typescript command created `new MetaDatabase()` without one → `Cannot read properties of undefined (reading 'addJob')`, no definitions produced. Now gives it a started loopback `JobQueue` (stopped afterwards).
- **`--exclude` ignored in output:** it only filtered scanning, but the `.d.ts` is generated from the whole meta db, which `load()` repopulates from the persisted `db.json`. `loadFromDirectories` now also drops classes whose source file matches the ignore patterns (guarding against `..` paths the `ignore` package rejects).